### PR TITLE
GL shader fixes on macOS

### DIFF
--- a/cmake/treedata/osx/subdirs.txt
+++ b/cmake/treedata/osx/subdirs.txt
@@ -11,4 +11,5 @@ xbmc/platform/darwin/osx/powermanagement platform/darwin/osx/powermanagement
 xbmc/platform/darwin/osx/storage      platform/osx/storage
 xbmc/windowing/osx                    windowing/osx
 xbmc/cores/RetroPlayer/process/osx    cores/RetroPlayer/process/osx
+xbmc/cores/RetroPlayer/shaders/gl     cores/RetroPlayer/shaders/gl
 xbmc/cores/VideoPlayer/Process/osx    cores/VideoPlayer/Process/osx

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -298,7 +298,9 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   if (it != m_RBTexturesMap.end())
   {
     rbTextures = it->second.get();
-  } else {
+  }
+  else
+  {
     // We can't copy or move CGLTexture, so construct source/target in-place
     rbTextures = new RenderBufferTextures{
       {   // source texture
@@ -324,6 +326,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   GLint filter = GL_NEAREST;
   if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
     filter = GL_LINEAR;
+
   glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
   glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -24,7 +24,6 @@ namespace RETRO
   class CRenderContext;
   class CRenderBufferOpenGL;
 
-
   class CRendererFactoryOpenGL : public IRendererFactory
   {
   public:

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -15,6 +15,7 @@
 #include "system_gl.h"
 
 #include <map>
+#include <memory>
 
 namespace KODI
 {

--- a/xbmc/cores/RetroPlayer/shaders/gl/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/shaders/gl/CMakeLists.txt
@@ -1,13 +1,16 @@
-set(SOURCES ShaderTextureGL.cpp
-        ShaderUtilsGL.cpp
-        ShaderPresetGL.cpp
-        ShaderLutGL.cpp
-        ShaderGL.cpp)
+set(SOURCES ShaderGL.cpp
+            ShaderLutGL.cpp
+            ShaderPresetGL.cpp
+            ShaderTextureGL.cpp
+            ShaderUtilsGL.cpp
+)
 
-set(HEADERS ShaderTextureGL.h
-        ShaderUtilsGL.h
-        ShaderLutGL.h
-        ShaderGL.h
-        ShaderTypesGL.h)
+set(HEADERS ShaderGL.h
+            ShaderLutGL.h
+            ShaderPresetGL.h
+            ShaderTextureGL.h
+            ShaderTypesGL.h
+            ShaderUtilsGL.h
+)
 
 core_add_library(rp-shaders-gl)

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -29,7 +29,7 @@ bool CShaderGL::Create(const std::string& shaderSource, const std::string& shade
         float2 viewPortSize, unsigned frameCountMod)
 {
   // TODO:Remove sampler input from IShader.h
-  if(shaderPath.empty())
+  if (shaderPath.empty())
   {
     CLog::Log(LOGERROR, "ShaderGL: Can't load empty shader path");
     return false;

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -14,6 +14,7 @@
 #include "guilib/TextureGL.h"
 #include "rendering/gl/GLShader.h"
 
+#include <array>
 #include <stdint.h>
 
 namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -32,7 +32,8 @@ class CShaderGL : public IShader
 {
 public:
   CShaderGL(RETRO::CRenderContext &context);
-//  ~CShaderGL() override;
+  ~CShaderGL() override = default;
+
   bool CreateVertexBuffer(unsigned vertCount, unsigned vertSize) override;
 
   // implementation of IShader

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
@@ -11,8 +11,8 @@
 
 #include "cores/RetroPlayer/shaders/IShaderLut.h"
 #include "cores/RetroPlayer/shaders/ShaderTypes.h"
+#include "system_gl.h"
 
-#include <GL/gl.h>
 #include <memory>
 #include <string>
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -37,6 +37,7 @@ CShaderPresetGL::CShaderPresetGL(RETRO::CRenderContext &context, unsigned int vi
 CShaderPresetGL::~CShaderPresetGL()
 {
   DisposeShaders();
+
   // The gui is going to render after this, so apply the state required
   m_context.ApplyStateBlock();
 }
@@ -55,11 +56,15 @@ ShaderParameterMap CShaderPresetGL::GetShaderParameters(const std::vector<Shader
   }
 
   ShaderParameterMap matchParams;
-  for (const auto& match : validParams)   // for each param found in the source code
+
+  // For each param found in the source code
+  for (const auto& match : validParams)
   {
-    for (const auto& parameter : parameters)   // for each param found in the preset file
+    // For each param found in the preset file
+    for (const auto& parameter : parameters)
     {
-      if (match == parameter.strId)  // if they match
+      // Check if they match
+      if (match == parameter.strId)
       {
         // The add-on has already handled parsing and overwriting default
         // parameter values from the preset file. The final value we
@@ -131,6 +136,7 @@ bool CShaderPresetGL::RenderUpdate(const CPoint *dest, IShaderTexture *source, I
       RenderShader(shader, prevTexture, target); // The target on each call is only used for setting the viewport
       texture->UnbindFBO();
     }
+
     // TODO: Remove last texture, useless
     // Apply last pass
     CShaderTextureGL* secToLastTexture = m_pShaderTextures[m_pShaderTextures.size() - 2].get();
@@ -164,7 +170,8 @@ bool CShaderPresetGL::Update()
     if (m_presetPath.empty())
       return false;
 
-    if (!ReadPresetFile(m_presetPath)) {
+    if (!ReadPresetFile(m_presetPath))
+    {
       CLog::Log(LOGERROR, "%s - couldn't load shader preset %s or the shaders it references", __func__, m_presetPath.c_str());
       return false;
     }
@@ -310,7 +317,6 @@ bool CShaderPresetGL::CreateShaderTextures()
     m_pShaders[shaderIdx]->SetSizes(prevSize, scaledSize);
 
     prevSize = scaledSize;
-
   }
   return true;
 }
@@ -319,6 +325,7 @@ bool CShaderPresetGL::CreateShaders()
 {
   auto numPasses = m_passes.size();
   m_textureSize = CShaderUtils::GetOptimalTextureSize(m_videoSize);
+
   ShaderLutVec passLUTsGL;
   for (unsigned shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
@@ -354,9 +361,8 @@ bool CShaderPresetGL::CreateShaders()
 bool CShaderPresetGL::CreateBuffers()
 {
   for (auto& videoShader : m_pShaders)
-  {
     videoShader->CreateInputBuffer();
-  }
+
   return true;
 }
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.h
@@ -13,9 +13,9 @@
 #include "cores/RetroPlayer/shaders/IShaderPreset.h"
 #include "cores/RetroPlayer/shaders/ShaderTypes.h"
 #include "games/GameServices.h"
+#include "system_gl.h"
 #include "utils/Geometry.h"
 
-#include <GL/gl.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
@@ -31,7 +31,7 @@ public:
   float GetWidth() const override { return static_cast<float>(m_texture->GetWidth()); }
   float GetHeight() const override { return static_cast<float>(m_texture->GetHeight()); }
 
-  CGLTexture *GetPointer() { return m_texture; }
+  CGLTexture* GetPointer() { return m_texture; }
   bool CreateFBO(int width, int height);
   void BindFBO();
   void UnbindFBO();

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.cpp
@@ -16,22 +16,24 @@ using namespace SHADER;
 
 GLint CShaderUtilsGL::TranslateWrapType(WRAP_TYPE wrap)
 {
-GLint glWrap;
-switch(wrap)
-{
-  case WRAP_TYPE_EDGE:
-    glWrap = GL_CLAMP_TO_EDGE;
-    break;
-  case WRAP_TYPE_REPEAT:
-    glWrap = GL_REPEAT;
-    break;
-  case WRAP_TYPE_MIRRORED_REPEAT:
-    glWrap = GL_MIRRORED_REPEAT;
-    break;
-  case WRAP_TYPE_BORDER:
-  default:
-    glWrap = GL_CLAMP_TO_BORDER;
+  GLint glWrap;
+  switch(wrap)
+  {
+    case WRAP_TYPE_EDGE:
+      glWrap = GL_CLAMP_TO_EDGE;
+      break;
+    case WRAP_TYPE_REPEAT:
+      glWrap = GL_REPEAT;
+      break;
+    case WRAP_TYPE_MIRRORED_REPEAT:
+      glWrap = GL_MIRRORED_REPEAT;
+      break;
+    case WRAP_TYPE_BORDER:
+    default:
+      glWrap = GL_CLAMP_TO_BORDER;
+      break;
   }
+
   return glWrap;
 }
 
@@ -39,6 +41,7 @@ void CShaderUtilsGL::MoveVersionToFirstLine(std::string &source, std::string &de
 {
   std::istringstream str_stream(source);
   source.clear();
+
   std::string line;
   bool firstLine = true;
   while (std::getline(str_stream, line))

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.h
@@ -9,8 +9,7 @@
 #pragma once
 
 #include "cores/RetroPlayer/shaders/ShaderTypes.h"
-
-#include <GL/gl.h>
+#include "system_gl.h"
 
 namespace KODI
 {


### PR DESCRIPTION
With these fixes (and the manual glsl folder copy), I can view a list of shaders in the Video Filters dialog. Shader presets fail to load, but I need to rebuild game.shader.presets with debug symbols to find out why. At least shader presets fail gracefully, and show a NN image when focused.